### PR TITLE
Use official grammarly API

### DIFF
--- a/lsp-grammarly.el
+++ b/lsp-grammarly.el
@@ -255,8 +255,8 @@ For argument CALLBACK, see object `lsp--client' description."
 
 (lsp-dependency 'grammarly-ls
                 '(:system "grammarly-ls")
-                '(:npm :package "@emacs-grammarly/unofficial-grammarly-language-server"
-                       :path "unofficial-grammarly-language-server"))
+                '(:npm :package "@emacs-grammarly/grammarly-languageserver"
+                       :path "grammarly-languageserver"))
 
 (lsp-register-client
  (make-lsp-client


### PR DESCRIPTION
With newest changes from the language server; the old language server [unofficial-grammarly-language-server](https://github.com/emacs-grammarly/unofficial-grammarly-language-server) is deprecated. We now move to the new one, [grammarly-language-server](https://github.com/emacs-grammarly/grammarly-language-server) which uses the official grammarly SDK.