### PR TITLE
Update client for the upstream changes

### DIFF
--- a/lsp-grammarly.el
+++ b/lsp-grammarly.el
@@ -417,6 +417,9 @@ For argument CALLBACK, see object `lsp--client' description."
 ;; (@* "Server" )
 ;;
 
+(defconst lsp-grammarly-client-id "client_BaDkMgx4X19X9UxxYRCXZo"
+  "Client ID is required for language server's activation.")
+
 (defun lsp-grammarly--server-command ()
   "Generate startup command for Grammarly language server."
   (or (and lsp-grammarly-server-path
@@ -467,6 +470,9 @@ For argument CALLBACK, see object `lsp--client' description."
 (lsp-register-client
  (make-lsp-client
   :new-connection (lsp-stdio-connection #'lsp-grammarly--server-command)
+  :initialization-options
+  `((clientId . ,lsp-grammarly-client-id)
+    (name . "Grammarly"))
   :activation-fn (lambda (&rest _) (apply #'derived-mode-p lsp-grammarly-active-modes))
   :priority -1
   :add-on? t

--- a/lsp-grammarly.el
+++ b/lsp-grammarly.el
@@ -6,7 +6,7 @@
 ;; Author: Shen, Jen-Chieh <jcs090218@gmail.com>
 ;; Description: LSP Clients for Grammarly.
 ;; Keyword: lsp grammarly checker
-;; Version: 0.3.0
+;; Version: 0.3.1
 ;; Package-Requires: ((emacs "27.1") (lsp-mode "6.1") (grammarly "0.3.0") (request "0.3.0") (s "1.12.0") (ht "2.3"))
 ;; URL: https://github.com/emacs-grammarly/lsp-grammarly
 


### PR DESCRIPTION
PR to make the Emacs client (lsp-mode) work for [grammarly-language-server](https://github.com/emacs-grammarly/grammarly-language-server).