### PR TITLE
tests(activate): attempt to fix activate test

### DIFF
--- a/test/activate.el
+++ b/test/activate.el
@@ -42,7 +42,7 @@
                                         (string-trim (shell-command-to-string
                                                       (mapconcat #'shell-quote-argument `(,npm-binary "view" ,package "peerDependencies") " "))))
                                        callback
-                                     (let ((default-directory (f-join lsp-server-install-dir "npm" package "lib" "node_modules" package)))
+                                     (let ((default-directory (f-dirname (car (last (directory-files-recursively (f-join lsp-server-install-dir "npm" package) "package.json"))))))
                                        (when (f-dir-p default-directory)
                                          (lsp-async-start-process callback
                                                                   error-callback

--- a/test/activate.el
+++ b/test/activate.el
@@ -58,6 +58,7 @@
     (lsp-log "Unable to install %s via `npm' because it is not present" package)
     nil))
 
+
 (lsp-install-server t 'grammarly-ls)  ; Start installation
 
 (defconst timeout 180

--- a/test/activate.el
+++ b/test/activate.el
@@ -43,13 +43,4 @@
                            (string-prefix-p "*lsp-install:" (buffer-name buf)))
                          (buffer-list))))
 
-(with-current-buffer (get-lsp-install-buffer)
-  (while (not (string-match-p "^Comint" (thing-at-point 'line)))
-    (goto-char (point-max))
-    (forward-line -1)
-    (sit-for 5)
-    (cl-incf timer 5)
-    (message "%s" (buffer-string))
-    (message "Waited %s..." timer)))
-
 ;;; activate.el ends here

--- a/test/activate.el
+++ b/test/activate.el
@@ -45,10 +45,10 @@
 
 (with-current-buffer (get-lsp-install-buffer)
   (while (not (string-match-p "^Comint" (thing-at-point 'line)))
-    
+    (goto-char (point-max))
+    (forward-line -1)
+    (sit-for 5)
     (cl-incf timer 5)
-    (message "Waited %s..." timer)
-    )
-  )
+    (message "Waited %s..." timer)))
 
 ;;; activate.el ends here

--- a/test/activate.el
+++ b/test/activate.el
@@ -44,7 +44,11 @@
                          (buffer-list))))
 
 (with-current-buffer (get-lsp-install-buffer)
-  
+  (while (not (string-match-p "^Comint" (thing-at-point 'line)))
+    
+    (cl-incf timer 5)
+    (message "Waited %s..." timer)
+    )
   )
 
 ;;; activate.el ends here

--- a/test/activate.el
+++ b/test/activate.el
@@ -43,15 +43,13 @@
                            (string-prefix-p "*lsp-install:" (buffer-name buf)))
                          (buffer-list))))
 
-(defconst server-install-path (lsp-package-path 'grammarly-ls)
-  "The server install location.")
-
-(unless (file-exists-p server-install-path)
-  (error "Failed to install server: %s" server-install-path)
-  (kill-emacs 1))
-
-(message "Testing with a file...")
-
-(find-file "README.md")  ; start lsp
+(with-current-buffer (get-lsp-install-buffer)
+  (while (not (string-match-p "^Comint" (thing-at-point 'line)))
+    (goto-char (point-max))
+    (forward-line -1)
+    (sit-for 5)
+    (cl-incf timer 5)
+    (message "%s" (buffer-string))
+    (message "Waited %s..." timer)))
 
 ;;; activate.el ends here

--- a/test/activate.el
+++ b/test/activate.el
@@ -31,4 +31,18 @@
 
 (lsp-install-server t 'grammarly-ls)  ; Start installation
 
+(defconst timeout 180
+  "Timeout in seconds.")
+
+(defvar timer 0)
+
+(defun get-lsp-install-buffer ()
+  "Get lsp-insall buffer."
+  (nth 0
+       (cl-remove-if-not (lambda (buf)
+                           (string-prefix-p "*lsp-install:" (buffer-name buf)))
+                         (buffer-list))))
+
+(message "test: %s" (get-lsp-install-buffer))
+
 ;;; activate.el ends here

--- a/test/activate.el
+++ b/test/activate.el
@@ -43,4 +43,23 @@
                            (string-prefix-p "*lsp-install:" (buffer-name buf)))
                          (buffer-list))))
 
+(with-current-buffer (get-lsp-install-buffer)
+  (while (not (string-match-p "^Comint" (thing-at-point 'line)))
+    (goto-char (point-max))
+    (forward-line -1)
+    (sit-for 1)
+    (cl-incf timer 1)
+    (message "Waited %s..." timer)))
+
+(defconst server-install-path (lsp-package-path 'grammarly-ls)
+  "The server install location.")
+
+(unless (file-exists-p server-install-path)
+  (error "Failed to install server: %s" server-install-path)
+  (kill-emacs 1))
+
+(message "Testing with a file...")
+
+(find-file "README.md")  ; start lsp
+
 ;;; activate.el ends here

--- a/test/activate.el
+++ b/test/activate.el
@@ -37,7 +37,17 @@
         ;; https://github.com/emacs-lsp/lsp-mode/issues/2364 for
         ;; discussion.
         (make-directory (f-join lsp-server-install-dir "npm" package "lib") 'parents)
-        (lsp-async-start-process callback
+        (lsp-async-start-process (lambda ()
+                                   (if (string-empty-p
+                                        (string-trim (shell-command-to-string
+                                                      (mapconcat #'shell-quote-argument `(,npm-binary "view" ,package "peerDependencies") " "))))
+                                       callback
+                                     (let ((default-directory (f-join lsp-server-install-dir "npm" package "lib" "node_modules" package)))
+                                       (when (f-dir-p default-directory)
+                                         (lsp-async-start-process callback
+                                                                  error-callback
+                                                                  (executable-find "npx")
+                                                                  "npm-install-peers")))))
                                  error-callback
                                  npm-binary
                                  "-g"

--- a/test/activate.el
+++ b/test/activate.el
@@ -54,12 +54,4 @@
 (defconst server-install-path (lsp-package-path 'grammarly-ls)
   "The server install location.")
 
-(unless (file-exists-p server-install-path)
-  (error "Failed to install server: %s" server-install-path)
-  (kill-emacs 1))
-
-(message "Testing with a file...")
-
-(find-file "README.md")  ; start lsp
-
 ;;; activate.el ends here

--- a/test/activate.el
+++ b/test/activate.el
@@ -43,12 +43,15 @@
                            (string-prefix-p "*lsp-install:" (buffer-name buf)))
                          (buffer-list))))
 
-(with-current-buffer (get-lsp-install-buffer)
-  (while (not (string-match-p "^Comint" (thing-at-point 'line)))
-    (goto-char (point-max))
-    (forward-line -1)
-    (sit-for 5)
-    (cl-incf timer 5)
-    (message "Waited %s..." timer)))
+(defconst server-install-path (lsp-package-path 'grammarly-ls)
+  "The server install location.")
+
+(unless (file-exists-p server-install-path)
+  (error "Failed to install server: %s" server-install-path)
+  (kill-emacs 1))
+
+(message "Testing with a file...")
+
+(find-file "README.md")  ; start lsp
 
 ;;; activate.el ends here

--- a/test/activate.el
+++ b/test/activate.el
@@ -43,6 +43,8 @@
                            (string-prefix-p "*lsp-install:" (buffer-name buf)))
                          (buffer-list))))
 
-(message "test: %s" (get-lsp-install-buffer))
+(with-current-buffer (get-lsp-install-buffer)
+  
+  )
 
 ;;; activate.el ends here

--- a/test/activate.el
+++ b/test/activate.el
@@ -31,27 +31,4 @@
 
 (lsp-install-server t 'grammarly-ls)  ; Start installation
 
-(defconst timeout 180
-  "Timeout in seconds.")
-
-(defvar timer 0)
-
-(defun get-lsp-install-buffer ()
-  "Get lsp-insall buffer."
-  (nth 0
-       (cl-remove-if-not (lambda (buf)
-                           (string-prefix-p "*lsp-install:" (buffer-name buf)))
-                         (buffer-list))))
-
-(with-current-buffer (get-lsp-install-buffer)
-  (while (not (string-match-p "^Comint" (thing-at-point 'line)))
-    (goto-char (point-max))
-    (forward-line -1)
-    (sit-for 5)
-    (cl-incf timer 5)
-    (message "Waited %s..." timer)))
-
-(defconst server-install-path (lsp-package-path 'grammarly-ls)
-  "The server install location.")
-
 ;;; activate.el ends here

--- a/test/activate.el
+++ b/test/activate.el
@@ -47,16 +47,22 @@
   (while (not (string-match-p "^Comint" (thing-at-point 'line)))
     (goto-char (point-max))
     (forward-line -1)
-    (sit-for 1)
-    (cl-incf timer 1)
+    (sit-for 5)
+    (cl-incf timer 5)
     (message "Waited %s..." timer)))
+
+(message "wait! 1")
 
 (defconst server-install-path (lsp-package-path 'grammarly-ls)
   "The server install location.")
 
+(message "wait! 2")
+
 (unless (file-exists-p server-install-path)
   (error "Failed to install server: %s" server-install-path)
   (kill-emacs 1))
+
+(message "wait! 3")
 
 (message "Testing with a file...")
 


### PR DESCRIPTION
Fixing activate test in Windows, see log below.

```
Loading d:/a/lsp-grammarly/lsp-grammarly/test/activate.el (source)...
Loading package information... done ✓
LSP :: Download grammarly-ls started.
Comint finished
No such directory: d:/a/lsp-grammarly/lsp-grammarly/.eask/28.1/.cache/lsp/npm/@emacs-grammarly/grammarly-languageserver/lib/node_modules/@emacs-grammarly/grammarly-languageserver
C:\npm\prefix\node_modules\@emacs-eask\eask\src\util.js:139
      throw 'Exit with code: ' + code;
      ^
Exit with code: 1
(Use `node --trace-uncaught ...` to show where the exception was thrown)
mingw32-make: *** [makefile:37: activate] Error 1
Error: Process completed with exit code 1.
```